### PR TITLE
chore: add parent element validation tip

### DIFF
--- a/src/core/watermark.ts
+++ b/src/core/watermark.ts
@@ -136,6 +136,10 @@ class Watermark {
     } else {
       this.parentElement = parent
     }
+
+    if (!this.parentElement) {
+      console.error('[WatermarkJsPlus]: please pass a valid parent element.')
+    }
   }
 
   private validateUnique (): boolean {


### PR DESCRIPTION
when a parent prop is passed to watermark config, if this parent prop is invalid(e.g. an unmounted html element), watermark will be rendered on document body. I think it's not appropriate, and it's better to notify user with a tip.